### PR TITLE
Allow plugins to be registered before Vue is mounted

### DIFF
--- a/resources/js/mingleReact.jsx
+++ b/resources/js/mingleReact.jsx
@@ -15,7 +15,15 @@ const createComponent = (mingleId, wireId, Component) => {
 
     const root = createRoot(el)
 
-    root.render(<Component wire={wire} wireId={wireId} mingleData={JSON.parse(el.dataset.mingleData)} />)
+    let mingleData = JSON.parse(el.dataset.mingleData);
+
+    root.render(<Component wire={wire} wireId={wireId} mingleData={mingleData} />)
+
+    return {
+        root,
+        node: el,
+        mingleData
+    }
 }
 
 const registerReactMingle = (name, component) => {

--- a/resources/js/mingleReact.jsx
+++ b/resources/js/mingleReact.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {createRoot} from 'react-dom/client'
 
-const createComponent = (mingleId, wireId, Component) => {
+const createComponent = (mingleId, wireId, Component, options = {}) => {
 
     const
         el = document.getElementById(mingleId),

--- a/resources/js/mingleVue.js
+++ b/resources/js/mingleVue.js
@@ -37,6 +37,12 @@ const createComponent = (mingleId, wireId, component, options = { autoMount: tru
     if (options.autoMount) {
         app.mount(el)
     }
+
+    return {
+        app,
+        node: el,
+        mingleData,
+    }
 }
 
 const registerVueMingle = (name, component) => {

--- a/resources/js/mingleVue.js
+++ b/resources/js/mingleVue.js
@@ -34,7 +34,9 @@ const createComponent = (mingleId, wireId, component, options = { autoMount: tru
 
     const app = createApp(component, props)
 
-    app.mount(el)
+    if (options.autoMount) {
+        app.mount(el)
+    }
 }
 
 const registerVueMingle = (name, component) => {

--- a/resources/js/mingleVue.js
+++ b/resources/js/mingleVue.js
@@ -1,6 +1,6 @@
 import {createApp} from 'vue/dist/vue.esm-bundler'
 
-const createComponent = (mingleId, wireId, component) => {
+const createComponent = (mingleId, wireId, component, options = { autoMount: true }) => {
 
     const
         el = document.getElementById(mingleId),


### PR DESCRIPTION
This PR allows for conditionally auto-mounting the Vue component, allowing for any Vue plugins to be registered before mounting.
No breaking changes, this is fully backwards compatible. Default behaviour is still to auto-mount the component.
Also updated the React component flow for consistency (also no breaking changes, fully backwards compatible)

Changelog:
- Adds an options argument to the mingleVue createComponent function, allowing to pass `autoMount: false`
- Also added an options argument to the mingleReact createComponent function, for consistency.
- Add return values to the mingleVue createComponent function, allowing for "manual" mounting.
- Also added return values to the mingleReact createComponent function, for consistency.

Fixes https://github.com/ijpatricio/mingle/issues/17
Supersedes https://github.com/ijpatricio/mingle/pull/14