### PR TITLE
feature/properly-expose-return-values-via-promise

### DIFF
--- a/resources/js/mingleReact.jsx
+++ b/resources/js/mingleReact.jsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import {createRoot} from 'react-dom/client'
 
-const createComponent = (mingleId, wireId, Component, options = {}) => {
+const defaultOptions = {
+    
+ };
+
+const createComponent = (mingleId, wireId, Component, options = defaultOptions) => {
 
     const
         el = document.getElementById(mingleId),
@@ -26,16 +30,27 @@ const createComponent = (mingleId, wireId, Component, options = {}) => {
     }
 }
 
-const registerReactMingle = (name, component) => {
-    window.Mingle = window.Mingle || {
-        Elements: {}
-    }
-
-    window.Mingle.Elements[name] = {
-        boot(mingleId, wireId) {
-            createComponent(mingleId, wireId, component)
-        }
-    }
+const registerReactMingle = (name, component, options = defaultOptions) => {
+    return new Promise((resolve, reject) => {
+        window.Mingle = window.Mingle || {
+            Elements: {},
+        };
+  
+        window.Mingle.Elements[name] = {
+            boot(mingleId, wireId) {
+                try {
+                    const result = createComponent(mingleId, wireId, component, options);
+                    if (result) {
+                        resolve(result);
+                    } else {
+                        reject(new Error('Component creation failed'));
+                    }
+                } catch (error) {
+                    reject(error);
+                }
+            },
+        };
+    });
 }
 
 export default registerReactMingle

--- a/resources/js/mingleVue.js
+++ b/resources/js/mingleVue.js
@@ -1,6 +1,10 @@
 import {createApp} from 'vue/dist/vue.esm-bundler'
 
-const createComponent = (mingleId, wireId, component, options = { autoMount: true }) => {
+const defaultOptions = {
+    autoMount: false,
+ };
+ 
+const createComponent = (mingleId, wireId, component, options = defaultOptions) => {
 
     const
         el = document.getElementById(mingleId),
@@ -45,16 +49,27 @@ const createComponent = (mingleId, wireId, component, options = { autoMount: tru
     }
 }
 
-const registerVueMingle = (name, component) => {
-    window.Mingle = window.Mingle || {
-        Elements: {}
-    }
-
-    window.Mingle.Elements[name] = {
-        boot(mingleId, wireId) {
-            createComponent(mingleId, wireId, component)
-        }
-    }
+const registerVueMingle = (name, component, options = defaultOptions) => {
+    return new Promise((resolve, reject) => {
+        window.Mingle = window.Mingle || {
+            Elements: {},
+        };
+  
+        window.Mingle.Elements[name] = {
+            boot(mingleId, wireId) {
+                try {
+                    const result = createComponent(mingleId, wireId, component, options);
+                    if (result) {
+                        resolve(result);
+                    } else {
+                        reject(new Error('Component creation failed'));
+                    }
+                } catch (error) {
+                    reject(error);
+                }
+            },
+        };
+     });
 }
 
 export default registerVueMingle

--- a/resources/js/mingleVue.js
+++ b/resources/js/mingleVue.js
@@ -1,7 +1,7 @@
 import {createApp} from 'vue/dist/vue.esm-bundler'
 
 const defaultOptions = {
-    autoMount: false,
+    autoMount: true,
  };
  
 const createComponent = (mingleId, wireId, component, options = defaultOptions) => {


### PR DESCRIPTION
Hey Patricio, thanks for merging my earlier PR #18 !

Seems like I was a little bit too hasty though in my implementation... I wasn't taking into consideration that the createComponent function is executed on 'mingle boot', and was overlooking that it's not the createComponent function that is being exported, but the `registerVueMingle` / `registerReactMingle` function...

---

Sorry, I should have properly tested that. After pulling the latest changes from `v0.0.15` and noticing that my earlier work didn't work properly, I realized I needed to use a Promise here.

Would you have time to please revise this again ?
This time I have actually tested this locally and it works as expected.
We can now register Vue plugins as follows:

---


```
import registerVueMingle from '@mingle/mingleVue';
import MyComponent from '@/components/my-component/MyComponent.vue';
import i18n from '@/utils/createi18n';

const promise = registerVueMingle('resources/js/components/my-component/index.js', MyComponent, { autoMount: false });

promise.then(({ app, node }) => {
   app.use(i18n);
   app.mount(node);
});

```

Of course, the default flow with `autoMount: true` still works - no promises required here.

```
import registerVueMingle from '@mingle/mingleVue';
import MyComponent from '@/components/my-component/MyComponent.vue';

registerVueMingle('resources/js/components/my-component/index.js', MyComponent);
```
