### PR TITLE
Add Laravel 12 Livewire starter support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Fork and clone the repository.
 
 ```
 # Pre-requisites
-./run prepare-repo
+./run prepare:repo
 
 # PHP server (wrapper project), will run on the port defined in `wrapper-mingle/.env` file.
 ./run dev:server

--- a/resources/stubs/mingle.laravel12livewirestarter.stub
+++ b/resources/stubs/mingle.laravel12livewirestarter.stub
@@ -1,0 +1,32 @@
+<?php
+
+namespace {{ namespace }};
+
+use Ijpatricio\Mingle\Concerns\InteractsWithMingles;
+use Ijpatricio\Mingle\Contracts\HasMingles;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('components.layouts.mingle')] 
+class {{ class }} extends Component implements HasMingles
+{
+    use InteractsWithMingles;
+
+    public function component(): string
+    {
+        return '{{ $mingleFilePath }}';
+    }
+
+    public function mingleData(): array
+    {
+        return [
+            'message' => 'Message in a bottle 🍾',
+        ];
+    }
+
+    public function doubleIt($amount)
+    {
+        return $amount * 2;
+    }
+}

--- a/resources/stubs/mingle.layout.stub
+++ b/resources/stubs/mingle.layout.stub
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html class="dark" lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <title>{{ $title ?? config('app.name', 'Mingle Example') }}</title>
+        
+        <link href="/img/logo.ico" rel="icon" sizes="any">        
+        <link type="image/svg+xml" href="/favicon.svg" rel="icon">
+        <link href="/apple-touch-icon.png" rel="apple-touch-icon">
+
+        <link href="https://fonts.bunny.net" rel="preconnect">
+        <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+
+<!-- Please Confirm this -->
+        {{-- Not sure if this is still required, may be the doc needs updating ? https://minglejs.unitedbycode.com/manual-instructions#layout-files  --}}
+        {{-- @mingles --}}
+<!-- End -->
+        
+        @stack('scripts')
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @fluxAppearance
+    </head>
+
+    <body class="relative font-sans antialiased">
+        <flux:main>
+            {{ $slot }}
+        </flux:main>
+        @fluxScripts
+    </body>
+
+</html>

--- a/src/Actions/CreateMingleLayout.php
+++ b/src/Actions/CreateMingleLayout.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Ijpatricio\Mingle\Actions;
+
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * Creates a Mingle layout file at a specified location.
+ * 
+ * This class copies a stub file from resources/stubs/mingle.layout.stub
+ * to the target directory as mingle.blade.php. It will create the target
+ * directory if it doesn't exist.
+ * 
+ */
+class CreateMingleLayout
+{
+    protected $filePath;
+
+    public function __construct($filePath)
+    {
+        $this->filePath = $filePath;
+    }
+
+    /**
+     * Invokes the action to create the Mingle layout file.
+     *
+     * @return bool True if the file was created, false if it already exists.
+     */
+    public function __invoke()
+    {
+        // Path related pre setup
+        //
+        $fs = new Filesystem();
+        $layoutDir = base_path($this->filePath);
+        $stubPath = base_path('resources/stubs/mingle.layout.stub');
+        $targetPath = $layoutDir . '/mingle.blade.php';
+
+        // Create the target directory if it doesn't exist
+        //
+        if (!$fs->exists($layoutDir)) {
+            $fs->makeDirectory($layoutDir, 0755, true);
+        } 
+        
+        // If the target file already exists, do not overwrite and return false
+        // Could implement complex logic to identify code differences and prompt user take action
+        //
+        if ($fs->exists($targetPath)) {
+            return false; 
+        }
+
+        // Read the contents of the stub file and write it to the target file
+        //
+        $stub = $fs->get($stubPath);
+        $fs->put($targetPath, $stub);
+
+        return true;
+    }
+}

--- a/src/Commands/MingleInstallerCommand.php
+++ b/src/Commands/MingleInstallerCommand.php
@@ -5,6 +5,7 @@ namespace Ijpatricio\Mingle\Commands;
 use Ijpatricio\Mingle\Actions\AddDemoViewAndRoute;
 use Ijpatricio\Mingle\Actions\ChangeViteConfig;
 use Ijpatricio\Mingle\Actions\ChangeLayoutFile;
+use Ijpatricio\Mingle\Actions\CreateMingleLayout;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 
@@ -15,7 +16,7 @@ class MingleInstallerCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'mingle:install {--with-demo}';
+    protected $signature = 'mingle:install {--with-demo} {--for-laravel-12-livewire-starter} {--l12ls}';
 
     /**
      * The console command description.
@@ -29,11 +30,26 @@ class MingleInstallerCommand extends Command
      */
     public function handle()
     {
-        $results = collect([
-            app(ChangeLayoutFile::class, ['filePath' => 'resources/views/layouts/guest.blade.php',])(),
-            app(ChangeLayoutFile::class, ['filePath' => 'resources/views/layouts/app.blade.php',])(),
-            app(ChangeViteConfig::class)(),
-        ]);
+        // Check if the user is using Laravel 12 Livewire Starter using either of the optional options
+        //
+        $useL12ls = $this->option('for-laravel-12-livewire-starter') || $this->option('l12ls');
+        
+        // If it is a laravel 12 livewire starter, we will use the new layout file
+        // else we will retain the existing code logic for now (was working with laravel 11)
+        // Potential option would be to consider enabling option selection without for no param command
+        //
+        if ($useL12ls) {
+            $results = collect([
+                app(CreateMingleLayout::class, ['filePath' => 'resources/views/components/layouts'])(),
+                app(ChangeViteConfig::class)(),
+            ]);
+        } else {
+            $results = collect([
+                app(ChangeLayoutFile::class, ['filePath' => 'resources/views/layouts/guest.blade.php',])(),
+                app(ChangeLayoutFile::class, ['filePath' => 'resources/views/layouts/app.blade.php',])(),
+                app(ChangeViteConfig::class)(),
+            ]);
+        }
 
         if ($this->option('with-demo')) {
             $results->push(
@@ -47,6 +63,8 @@ class MingleInstallerCommand extends Command
             ]);
         }
 
+        // If decided to make the layout creation more interactive this logic will need updating
+        //
         if ($results->every(fn($result) => $result === false)) {
             $this->warn('Some files were not changed. Nothing to do.');
             return;


### PR DESCRIPTION
Update contributing guidelines for command syntax and enhance the MingleInstallerCommand to support Laravel 12 by adding a new parameter and creating a layout stub. Duplicate existing stubs to accommodate new layout usages.
- Added support for Laravel 12 Livewire Starter in MingleInstallerCommand and create layout stub
- Added parameter to Install command to support laravel 12
- Created layout stub for minle so that it does not expect it to already exist
- Duplicated mingle livewire stub to coply with new layout usages (original stub is still there)
- Created action to copy stub into desired layout location